### PR TITLE
Add icon font and replace sort arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -515,9 +516,9 @@
                       title="排序"
                     >
                       {sort.key === col.dataIndex
-                        ? (sort.order === "asc" ? "▲" : "▼")
-                        : "▲▼"}
-                    </button>
+                        ? (sort.order === "asc" ? <i className="bi bi-caret-up-fill" /> : <i className="bi bi-caret-down-fill" />)
+                        : <><i className="bi bi-caret-up" /><i className="bi bi-caret-down" /></>}
+                      </button>
                   </th>
                 ))}
               </tr>
@@ -632,9 +633,9 @@
                       title="排序"
                     >
                       {sort.key === col.dataIndex
-                        ? (sort.order === "asc" ? "▲" : "▼")
-                        : "▲▼"}
-                    </button>
+                        ? (sort.order === "asc" ? <i className="bi bi-caret-up-fill" /> : <i className="bi bi-caret-down-fill" />)
+                        : <><i className="bi bi-caret-up" /><i className="bi bi-caret-down" /></>}
+                      </button>
                   </th>
                 ))}
               </tr>


### PR DESCRIPTION
## Summary
- include Bootstrap Icons
- use icon elements for sort arrows in headers

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685289ce48308333bfc77ba13b7e716c